### PR TITLE
Use as_bytes() instead of as_string() to generate mbox

### DIFF
--- a/django/archives/mailarchives/views.py
+++ b/django/archives/mailarchives/views.py
@@ -587,7 +587,7 @@ def _build_mbox(query, params, msgid=None):
         s = BytesIO(raw)
         parser = email.parser.BytesParser(policy=email.policy.compat32)
         msg = parser.parse(s)
-        return msg.as_string(unixfrom=True)
+        return msg.as_bytes(unixfrom=True)
 
     def _message_stream(first):
         yield _one_message(first[1])


### PR DESCRIPTION
We're supposed to feed django bytes, and by feeding it a string it got
converted bytes->string by the mail end and then string->bytes by
django. Which promptly blew up on bad encodings. By keeping it as bytes
all the way, the problem is ignored.